### PR TITLE
Use codecs.getwriter for output streams

### DIFF
--- a/nmt/inference.py
+++ b/nmt/inference.py
@@ -108,7 +108,7 @@ def _decode_inference_indices(model, sess, output_infer,
                   (output_infer, len(inference_indices)))
   start_time = time.time()
   with codecs.getwriter("utf-8")(
-      tf.gfile.GFile(output_infer, mode="w")) as trans_f:
+      tf.gfile.GFile(output_infer, mode="wb")) as trans_f:
     trans_f.write("")  # Write empty string to ensure file is created.
     for decode_id in inference_indices:
       nmt_outputs, infer_summary = model.decode(sess)
@@ -292,7 +292,7 @@ def _multi_worker_inference(model_creator,
 
     # Now write all translations
     with codecs.getwriter("utf-8")(
-        tf.gfile.GFile(final_output_infer, mode="w")) as final_f:
+        tf.gfile.GFile(final_output_infer, mode="wb")) as final_f:
       for worker_id in range(num_workers):
         worker_infer_done = "%s_done_%d" % (inference_output_file, worker_id)
         while not tf.gfile.Exists(worker_infer_done):

--- a/nmt/inference.py
+++ b/nmt/inference.py
@@ -107,7 +107,7 @@ def _decode_inference_indices(model, sess, output_infer,
   utils.print_out("  decoding to output %s , num sents %d." %
                   (output_infer, len(inference_indices)))
   start_time = time.time()
-  with codecs.getreader("utf-8")(
+  with codecs.getwriter("utf-8")(
       tf.gfile.GFile(output_infer, mode="w")) as trans_f:
     trans_f.write("")  # Write empty string to ensure file is created.
     for decode_id in inference_indices:
@@ -291,7 +291,7 @@ def _multi_worker_inference(model_creator,
     if jobid != 0: return
 
     # Now write all translations
-    with codecs.getreader("utf-8")(
+    with codecs.getwriter("utf-8")(
         tf.gfile.GFile(final_output_infer, mode="w")) as final_f:
       for worker_id in range(num_workers):
         worker_infer_done = "%s_done_%d" % (inference_output_file, worker_id)

--- a/nmt/utils/misc_utils.py
+++ b/nmt/utils/misc_utils.py
@@ -80,7 +80,7 @@ def load_hparams(model_dir):
   hparams_file = os.path.join(model_dir, "hparams")
   if tf.gfile.Exists(hparams_file):
     print_out("# Loading hparams from %s" % hparams_file)
-    with codecs.getreader("utf-8")(tf.gfile.GFile(hparams_file, "r")) as f:
+    with codecs.getreader("utf-8")(tf.gfile.GFile(hparams_file, "rb")) as f:
       try:
         hparams_values = json.load(f)
         hparams = tf.contrib.training.HParams(**hparams_values)
@@ -109,7 +109,7 @@ def save_hparams(out_dir, hparams):
   """Save hparams."""
   hparams_file = os.path.join(out_dir, "hparams")
   print_out("  saving hparams to %s" % hparams_file)
-  with codecs.getwriter("utf-8")(tf.gfile.GFile(hparams_file, "w")) as f:
+  with codecs.getwriter("utf-8")(tf.gfile.GFile(hparams_file, "wb")) as f:
     f.write(hparams.to_json())
 
 

--- a/nmt/utils/misc_utils.py
+++ b/nmt/utils/misc_utils.py
@@ -109,7 +109,7 @@ def save_hparams(out_dir, hparams):
   """Save hparams."""
   hparams_file = os.path.join(out_dir, "hparams")
   print_out("  saving hparams to %s" % hparams_file)
-  with codecs.getreader("utf-8")(tf.gfile.GFile(hparams_file, "w")) as f:
+  with codecs.getwriter("utf-8")(tf.gfile.GFile(hparams_file, "w")) as f:
     f.write(hparams.to_json())
 
 

--- a/nmt/utils/vocab_utils.py
+++ b/nmt/utils/vocab_utils.py
@@ -56,7 +56,7 @@ def check_vocab(vocab_file, out_dir, sos=None, eos=None, unk=None):
       vocab = [unk, sos, eos] + vocab
       vocab_size += 3
       new_vocab_file = os.path.join(out_dir, os.path.basename(vocab_file))
-      with codecs.getwriter("utf-8")(tf.gfile.GFile(new_vocab_file, "w")) as f:
+      with codecs.getwriter("utf-8")(tf.gfile.GFile(new_vocab_file, "wb")) as f:
         for word in vocab:
           f.write("%s\n" % word)
       vocab_file = new_vocab_file

--- a/nmt/utils/vocab_utils.py
+++ b/nmt/utils/vocab_utils.py
@@ -56,7 +56,7 @@ def check_vocab(vocab_file, out_dir, sos=None, eos=None, unk=None):
       vocab = [unk, sos, eos] + vocab
       vocab_size += 3
       new_vocab_file = os.path.join(out_dir, os.path.basename(vocab_file))
-      with codecs.getreader("utf-8")(tf.gfile.GFile(new_vocab_file, "w")) as f:
+      with codecs.getwriter("utf-8")(tf.gfile.GFile(new_vocab_file, "w")) as f:
         for word in vocab:
           f.write("%s\n" % word)
       vocab_file = new_vocab_file

--- a/nmt/utils/vocab_utils_test.py
+++ b/nmt/utils/vocab_utils_test.py
@@ -34,7 +34,7 @@ class VocabUtilsTest(tf.test.TestCase):
     os.makedirs(vocab_dir)
     vocab_file = os.path.join(vocab_dir, "vocab_file")
     vocab = ["a", "b", "c"]
-    with codecs.getreader("utf-8")(tf.gfile.GFile(vocab_file, "w")) as f:
+    with codecs.getwriter("utf-8")(tf.gfile.GFile(vocab_file, "w")) as f:
       for word in vocab:
         f.write("%s\n" % word)
 

--- a/nmt/utils/vocab_utils_test.py
+++ b/nmt/utils/vocab_utils_test.py
@@ -34,7 +34,7 @@ class VocabUtilsTest(tf.test.TestCase):
     os.makedirs(vocab_dir)
     vocab_file = os.path.join(vocab_dir, "vocab_file")
     vocab = ["a", "b", "c"]
-    with codecs.getwriter("utf-8")(tf.gfile.GFile(vocab_file, "w")) as f:
+    with codecs.getwriter("utf-8")(tf.gfile.GFile(vocab_file, "wb")) as f:
       for word in vocab:
         f.write("%s\n" % word)
 


### PR DESCRIPTION
For output streams, codecs.getwriter(.) should be used instead of codecs.getreader(.).