### PR TITLE
words per second fix

### DIFF
--- a/nmt/train.py
+++ b/nmt/train.py
@@ -383,7 +383,7 @@ def train(hparams, scope=None, target_session=""):
       # Print statistics for the previous epoch.
       avg_step_time = step_time / steps_per_stats
       train_ppl = utils.safe_exp(checkpoint_loss / checkpoint_predict_count)
-      speed = checkpoint_total_count / (1000 * step_time)
+      speed = checkpoint_total_count / step_time
       utils.print_out(
           "  global step %d lr %g "
           "step-time %.2fs wps %.2fK ppl %.2f %s" %


### PR DESCRIPTION
`time.time()` is measured in seconds, so `step_time` holds the total number of _seconds_ that have transpired between stats.

So I think this line
```
speed = checkpoint_total_count / (1000 * step_time )
```
is calculating words per **milli**second, not wps as is being reported.