### PR TITLE
fix encoding error when piping stdout to file

### DIFF
--- a/nmt/utils/misc_utils.py
+++ b/nmt/utils/misc_utils.py
@@ -23,6 +23,8 @@ import math
 import os
 import sys
 import time
+import locale
+sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
 import numpy as np
 import tensorflow as tf


### PR DESCRIPTION
The new code changes would raise `UnicodeDecodeError` on some terminals.

See [this stackoverflow](https://stackoverflow.com/a/4546129) for detailed explanation.