### PR TITLE
The minimal version does not allow release 1.4.0

### DIFF
--- a/nmt/utils/misc_utils.py
+++ b/nmt/utils/misc_utils.py
@@ -29,7 +29,7 @@ import tensorflow as tf
 
 
 def check_tensorflow_version():
-  min_tf_version = "1.4.0-dev20171024"
+  min_tf_version = "1.4.0"
   if tf.__version__ < min_tf_version:
     raise EnvironmentError("Tensorflow version must >= %s" % min_tf_version)
 


### PR DESCRIPTION
When running the execution fails if I use stable release 1.4.0 because of the current minimal version set in `check_tensorflow_version()`.