### PR TITLE
Set beam search length penalty to 1.0 by default

### DIFF
--- a/nmt/nmt.py
+++ b/nmt/nmt.py
@@ -248,7 +248,7 @@ def add_arguments(parser):
       beam width when using beam search decoder. If 0 (default), use standard
       decoder with greedy helper.\
       """))
-  parser.add_argument("--length_penalty_weight", type=float, default=0.0,
+  parser.add_argument("--length_penalty_weight", type=float, default=1.0,
                       help="Length penalty for beam search.")
   parser.add_argument("--num_translations_per_input", type=int, default=1,
                       help=("""\


### PR DESCRIPTION
Beam search has been shown to work much (much) better with this. 
I suggest we use it by default to help new users.

It is not part of the provided configs, either.