### PR TITLE
Update WMT16 standard hparams

### DIFF
--- a/nmt/standard_hparams/wmt16.json
+++ b/nmt/standard_hparams/wmt16.json
@@ -14,6 +14,8 @@
   "metrics": ["bleu"],
   "num_buckets": 5,
   "num_layers": 4,
+  "num_encoder_layers": 4,
+  "num_decoder_layers": 4,
   "num_train_steps": 340000,
   "decay_scheme": "luong10",
   "num_units": 1024,


### PR DESCRIPTION
"num_encoder_layers" and "num_decoder_layers" are set in nmt.create_hparams() (Line 595 in nmt.py), but not updated after calling nmt.misc_utils.maybe_parse_standard_hparams() (Line 497 in nmt.py). 

Fixes the issue (https://github.com/tensorflow/nmt/issues/264) where loading the pretrained checkpoint was resulting in an error.