### PR TITLE
removed source_reverse from wmt16_gnmt_8_layer.json, since this hpara…

### DIFF
--- a/nmt/standard_hparams/wmt16_gnmt_8_layer.json
+++ b/nmt/standard_hparams/wmt16_gnmt_8_layer.json
@@ -22,7 +22,6 @@
   "share_vocab": false,
   "subword_option": "bpe",
   "sos": "<s>",
-  "source_reverse": false,
   "src_max_len": 50,
   "src_max_len_infer": null,
   "steps_per_external_eval": null,


### PR DESCRIPTION
…m has been removed from NMT code, and it caused training and inference failures when use this .json file