### PR TITLE
Fix tensorflow version check

### DIFF
--- a/nmt/utils/misc_utils.py
+++ b/nmt/utils/misc_utils.py
@@ -25,12 +25,13 @@ import sys
 import time
 
 import numpy as np
+from distutils.version import LooseVersion, StrictVersion
 import tensorflow as tf
 
 
 def check_tensorflow_version():
   min_tf_version = "1.4.0-dev20171024"
-  if tf.__version__ < min_tf_version:
+  if LooseVersion(tf.__version__) < LooseVersion(min_tf_version):
     raise EnvironmentError("Tensorflow version must >= %s" % min_tf_version)
 
 


### PR DESCRIPTION
The current version, a string "1.11.0-dev20180813" is greater than the minimum version of "1.4.0-dev20171024". However, using string comparisons this check fails due to 1 being less than 4.