### PR TITLE
Smooth-BLEU bug fixed

### DIFF
--- a/nmt/scripts/bleu.py
+++ b/nmt/scripts/bleu.py
@@ -84,7 +84,7 @@ def compute_bleu(reference_corpus, translation_corpus, max_order=4,
 
   precisions = [0] * max_order
   for i in range(0, max_order):
-    if smooth:
+    if smooth and i > 0:
       precisions[i] = ((matches_by_order[i] + 1.) /
                        (possible_matches_by_order[i] + 1.))
     else:


### PR DESCRIPTION
Hi,
the current implementation of smooth-BLEU contains a bug: it smoothes unigrams as well. Consequently, when both the reference and translation consist of totally different tokens, it anyway returns a non-zero value (please see the attached image). 

This however contradicts the source paper suggesting the smooth-BLEU _(Chin-Yew Lin, Franz Josef Och. ORANGE: a method for evaluating automatic evaluation metrics for machine translation. COLING 2004.)_ :

> Add one count to the n-gram hit and total ngram count for n > 1. Therefore, for candidate translations with less than n words, they can still get a positive smoothed BLEU score from shorter n-gram matches; however if nothing matches then they will get zero scores. 

This pull request aims at fixing this bug.

<img width="544" alt="Снимок экрана 2022-06-29 в 17 39 42" src="https://user-images.githubusercontent.com/36672861/176464621-1952af55-a6df-4fbd-9fb1-830a9a180b20.png">
 